### PR TITLE
Strange behavior on showing HTML-ish text

### DIFF
--- a/src/content_scripts.js
+++ b/src/content_scripts.js
@@ -179,6 +179,7 @@ function searchSuccess(data) {
         })
     } else {
         let keyword = document.querySelector('#booqs-dict-search-keyword').textContent;
+        keyword =  keyword.replace(/</g, "&lt;").replace(/>/g, "&gt;");
         let notFound = `<div class="booqs-dict-meaning" style="margin: 24px 0;">${keyword}は辞書に登録されていません。</div>`
         let createNewWord = `<a href="https://www.booqs.net/ja/words/new?dict_uid=c6bbf748&text=${keyword}" target="_blank" rel="noopener"><div class="booqs-dict-review-btn" style="font-weight: bold;">辞書に登録する</div></a>`
         let result = notFound + createNewWord


### PR DESCRIPTION
I noticed some code interprets text as HTML.

![image](https://user-images.githubusercontent.com/515948/130326099-c47f566c-d938-4198-8afd-f08b3a305e83.png)


↓ maybe it should be...


![image](https://user-images.githubusercontent.com/515948/130326101-88374b25-1529-4caa-a742-c3711ce7746e.png)



----

Note: this PR's modification is just a rough ad-hoc implementation to try fixing it. May need a more total solution.